### PR TITLE
[young] #7 db 컬럼명, api 호출관련 수정

### DIFF
--- a/src/main/java/com/iot_sw/iot_web_backend/dashboard/entity/WeatherData.java
+++ b/src/main/java/com/iot_sw/iot_web_backend/dashboard/entity/WeatherData.java
@@ -1,8 +1,25 @@
 package com.iot_sw.iot_web_backend.dashboard.entity;
-import jakarta.persistence.*; 
-import lombok.*; 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Table(
+        indexes = {
+                @Index(name = "idx_weather_location_code", columnList = "location_code"),
+                @Index(name = "idx_weather_created_at", columnList = "created_at")
+        }
+)
 @Getter
 @Setter
 @Builder
@@ -14,10 +31,30 @@ public class WeatherData {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String tm;     // 시간
-    private Double wd;     // 풍향
-    private Double ws;     // 풍속
-    private Double ta;     // 기온
-    private Double hm;     // 습도
-    private Double rn;     // 강수량
+    @Column(name = "location_code")
+    private Integer locationCode;
+
+    @Column(name = "temp_ta")
+    private Double tempTa;
+
+    @Column(name = "wind_dir_wd")
+    private Double windDirWd;
+
+    @Column(name = "wind_speed_ws")
+    private Double windSpeedWs;
+
+    @Column(name = "humidity_hm")
+    private Double humidityHm;
+
+    @Column(name = "precipitation_rn")
+    private Double precipitationRn;
+
+    @Column(name = "is_strong_wind_warning")
+    private Byte isStrongWindWarning;
+
+    @Column(name = "is_dry_warning")
+    private Byte isDryWarning;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/iot_sw/iot_web_backend/dashboard/repository/WeatherRepository.java
+++ b/src/main/java/com/iot_sw/iot_web_backend/dashboard/repository/WeatherRepository.java
@@ -3,11 +3,12 @@ package com.iot_sw.iot_web_backend.dashboard.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.iot_sw.iot_web_backend.dashboard.entity.WeatherData;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface WeatherRepository extends JpaRepository<WeatherData, Long> {
 
-    boolean existsByTm(String tm);
+    boolean existsByCreatedAtAndLocationCode(LocalDateTime createdAt, Integer locationCode);
 
-    List<WeatherData> findAllByOrderByTmDesc();
+    List<WeatherData> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/iot_sw/iot_web_backend/dashboard/service/PublicApiService.java
+++ b/src/main/java/com/iot_sw/iot_web_backend/dashboard/service/PublicApiService.java
@@ -12,13 +12,14 @@ import java.time.format.DateTimeFormatter;
 
 import com.iot_sw.iot_web_backend.dashboard.entity.WeatherData;
 import com.iot_sw.iot_web_backend.dashboard.repository.WeatherRepository;
-
 @Service
 @RequiredArgsConstructor // final이 붙은 필드들을 파라미터로 받는 생성자를 생성합니다.
 public class PublicApiService {
     private static final DateTimeFormatter TM_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+    private static final int MIN_BACK_HOURS = 1;
 
     private final WeatherRepository weatherRepository;
+    private final WeatherAlertService weatherAlertService;
     
     // RestTemplate을 직접 생성하지 않고 생성자 주입을 받도록 변경합니다.
     private final RestTemplate restTemplate;
@@ -32,38 +33,93 @@ public class PublicApiService {
     @Value("${kma.stn}")
     private String stn;
 
-    public void fetchAndSave() {
-        ZoneId seoul = ZoneId.of("Asia/Seoul");
-        LocalDateTime base = LocalDateTime.now(seoul).withMinute(0).withSecond(0).withNano(0);
+    @Value("${weather.fetch.max-back-hours:3}")
+    private int maxBackHours;
 
-        for (int back = 0; back < 48; back++) {
+    @Value("${weather.fetch.cooldown-minutes:60}")
+    private long fetchCooldownMinutes;
+
+    private LocalDateTime lastFetchFailureAt;
+
+    public synchronized void fetchAndSave() {
+        if (authKey == null || authKey.isBlank()) {
+            System.err.println("kma.authKey가 비어 있어 날씨 API 호출을 건너뜁니다.");
+            return;
+        }
+
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+        LocalDateTime now = LocalDateTime.now(seoul);
+        if (isCooldownActive(now)) {
+            return;
+        }
+
+        LocalDateTime base = now.withMinute(0).withSecond(0).withNano(0);
+        int locationCode = parseLocationCode(stn);
+        boolean[] alert = weatherAlertService.getAlert();
+        byte isStrongWindWarning = alert[0] ? (byte) 1 : (byte) 0;
+        byte isDryWarning = alert[1] ? (byte) 1 : (byte) 0;
+        int backHoursToCheck = Math.max(MIN_BACK_HOURS, maxBackHours);
+        boolean attemptedExternalCall = false;
+
+        for (int back = 0; back < backHoursToCheck; back++) {
             LocalDateTime candidate = base.minusHours(back);
             String tm = candidate.format(TM_FORMATTER);
-            if (weatherRepository.existsByTm(tm)) {
+            if (weatherRepository.existsByCreatedAtAndLocationCode(candidate, locationCode)) {
                 continue;
             }
-            List<WeatherData> list = fetchForTm(tm);
-            if (!list.isEmpty()) {
-                weatherRepository.saveAll(list);
+            attemptedExternalCall = true;
+            FetchResult result = fetchForTm(tm, locationCode, isStrongWindWarning, isDryWarning);
+            if (result.error()) {
+                lastFetchFailureAt = now;
+                break;
+            }
+            if (!result.list().isEmpty()) {
+                lastFetchFailureAt = null;
+                weatherRepository.saveAll(result.list());
                 return;
             }
         }
+
+        if (attemptedExternalCall) {
+            // 빈 응답이 반복될 때 다음 주기에서 재호출 폭주를 막기 위해 쿨다운을 건다.
+            lastFetchFailureAt = now;
+        }
     }
 
-    private List<WeatherData> fetchForTm(String tm) {
+    private FetchResult fetchForTm(String tm, int locationCode, byte isStrongWindWarning, byte isDryWarning) {
         String requestUrl = String.format("%s?tm=%s&stn=%s&help=0&authKey=%s", url, tm, stn, authKey);
         try {
             String response = restTemplate.getForObject(requestUrl, String.class);
-            if (response != null) {
-                return parse(response);
+            if (response == null || response.isBlank()) {
+                System.err.println("[KMA:NO_RESPONSE] tm=" + tm + " 응답 본문이 비어 있습니다.");
+                return new FetchResult(List.of(), false);
             }
+
+            if (isLikelyApiErrorResponse(response)) {
+                System.err.println("[KMA:API_ERROR_RESPONSE] tm=" + tm + " 응답에 에러 문구가 포함되어 있습니다.");
+                return new FetchResult(List.of(), true);
+            }
+
+            int rawDataLineCount = countRawDataLines(response);
+            List<WeatherData> parsed = parse(response, locationCode, isStrongWindWarning, isDryWarning);
+            if (!parsed.isEmpty()) {
+                System.out.println("[KMA:DATA_OK] tm=" + tm + " rows=" + parsed.size());
+                return new FetchResult(parsed, false);
+            }
+
+            if (rawDataLineCount > 0) {
+                System.err.println("[KMA:PARSE_EMPTY] tm=" + tm + " 원본 데이터 라인은 있으나 파싱 결과가 0건입니다.");
+            } else {
+                System.out.println("[KMA:NO_DATA_FOR_TM] tm=" + tm + " 해당 시각 데이터가 없습니다.");
+            }
+            return new FetchResult(List.of(), false);
         } catch (Exception e) {
             System.err.println("API 호출 중 오류 발생 (tm=" + tm + "): " + e.getMessage());
+            return new FetchResult(List.of(), true);
         }
-        return List.of();
     }
 
-    private List<WeatherData> parse(String response) {
+    private List<WeatherData> parse(String response, int locationCode, byte isStrongWindWarning, byte isDryWarning) {
         List<WeatherData> list = new ArrayList<>();
         String[] lines = response.split("\n");
 
@@ -82,20 +138,71 @@ public class PublicApiService {
 
             try {
                 WeatherData weather = WeatherData.builder()
-                        .tm(data[0])
-                        .wd(Double.parseDouble(data[2]))
-                        .ws(Double.parseDouble(data[3]))
-                        .ta(Double.parseDouble(data[11]))
-                        .hm(Double.parseDouble(data[13]))
-                        .rn(Double.parseDouble(data[15]))
+                        .locationCode(locationCode)
+                        .windDirWd(Double.parseDouble(data[2]))
+                        .windSpeedWs(Double.parseDouble(data[3]))
+                        .tempTa(Double.parseDouble(data[11]))
+                        .humidityHm(Double.parseDouble(data[13]))
+                        .precipitationRn(Double.parseDouble(data[15]))
+                        .isStrongWindWarning(isStrongWindWarning)
+                        .isDryWarning(isDryWarning)
+                        .createdAt(LocalDateTime.parse(data[0], TM_FORMATTER))
                         .build();
 
                 list.add(weather);
-            } catch (NumberFormatException e) {
+            } catch (RuntimeException e) {
                 // 숫자 파싱 실패 시 해당 라인만 건너뜁니다.
                 continue;
             }
         }
         return list;
+    }
+
+    private int parseLocationCode(String locationCodeRaw) {
+        try {
+            return Integer.parseInt(locationCodeRaw);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private boolean isLikelyApiErrorResponse(String response) {
+        String normalized = response.toUpperCase();
+        return normalized.contains("ERROR")
+                || normalized.contains("ERR")
+                || normalized.contains("AUTH")
+                || normalized.contains("SERVICEKEY")
+                || normalized.contains("LIMIT")
+                || normalized.contains("한도")
+                || normalized.contains("인증");
+    }
+
+    private int countRawDataLines(String response) {
+        int count = 0;
+        String[] lines = response.split("\n");
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("TM")) {
+                continue;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    private boolean isCooldownActive(LocalDateTime now) {
+        if (lastFetchFailureAt == null) {
+            return false;
+        }
+
+        if (now.isBefore(lastFetchFailureAt.plusMinutes(fetchCooldownMinutes))) {
+            return true;
+        }
+
+        lastFetchFailureAt = null;
+        return false;
+    }
+
+    private record FetchResult(List<WeatherData> list, boolean error) {
     }
 }

--- a/src/main/java/com/iot_sw/iot_web_backend/dashboard/service/WeatherService.java
+++ b/src/main/java/com/iot_sw/iot_web_backend/dashboard/service/WeatherService.java
@@ -7,11 +7,13 @@ import com.iot_sw.iot_web_backend.dashboard.repository.WeatherRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class WeatherService {
+    private static final DateTimeFormatter TM_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
 
     private final WeatherRepository weatherRepository;
     private final WeatherAlertService alertService;
@@ -19,18 +21,18 @@ public class WeatherService {
     public WeatherResponseDto getWeather() {
 
         List<WeatherData> list =
-                weatherRepository.findAllByOrderByTmDesc();
+                weatherRepository.findAllByOrderByCreatedAtDesc();
 
         boolean[] alert = alertService.getAlert();
 
         List<WeatherDTO> dtoList = list.stream()
                 .map(w -> new WeatherDTO(
-                        w.getTm(),
-                        w.getWd(),
-                        w.getWs(),
-                        w.getTa(),
-                        w.getHm(),
-                        w.getRn()
+                        w.getCreatedAt() != null ? w.getCreatedAt().format(TM_FORMATTER) : null,
+                        w.getWindDirWd(),
+                        w.getWindSpeedWs(),
+                        w.getTempTa(),
+                        w.getHumidityHm(),
+                        w.getPrecipitationRn()
                 ))
                 .toList();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=IoT_web_backend
 weather.fetch.enabled=true
+weather.fetch.max-back-hours=3
+weather.fetch.cooldown-minutes=60
 kma.url=https://apihub.kma.go.kr/api/typ01/url/kma_sfctm2.php
 kma.authKey=${KMA_AUTH_KEY:}
 kma.stn=108


### PR DESCRIPTION
## 🚀 관련 이슈
close #7

## 개요
기상청 API 호출 로직에서 데이터 미존재, 오류 상황 시 과도한 재호출이 발생할 수 있는 부분 수정
PublicApiService의 과거 탐색 범위를 좁히고, 호출 실패 시 쿨다운을 적용해 한도 소모 위험을 줄였음
기상 데이터 엔티티 DB 컬럼명을 적절하게 수정


## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
